### PR TITLE
Add workflow to notify Portmap of content updates

### DIFF
--- a/.github/workflows/notify-portmap.yml
+++ b/.github/workflows/notify-portmap.yml
@@ -1,0 +1,19 @@
+name: Notify Portmap
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  notify-portmap:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Send repository_dispatch
+      uses: peter-evans/repository_dispatch@v3
+      with:
+        # GitHub personal access token.
+        # See action description for instructions and requirements.
+        token: ${{ secrets.PORTMAP_REPOSITORY_DISPATCH_PAT }}
+        repsoitory: dtinit/portmap
+        event-type: content_update


### PR DESCRIPTION
Closes https://github.com/dtinit/portmap/issues/78.

Uses a [community action](https://github.com/marketplace/actions/repository-dispatch) to notify the [Portmap repository](https://github.com/dtinit/portmap) when this repository's main branch is updated.

This requires a Personal Access Token for authentication. For now, it's using one with only the "public_repo" scope that's tied to my account and set to expire in 90 days.