### PR TITLE
Restructuring validations and workflows

### DIFF
--- a/.github/workflows/article-validator.yml
+++ b/.github/workflows/article-validator.yml
@@ -2,7 +2,9 @@ name: Article Validator
 
 on:
   pull_request:
-    types: [opened, reopened] 
+    types: [opened, reopened, synchronize]
+  push:
+    branches: [ "main" ]
 
 jobs:
   build:
@@ -18,7 +20,7 @@ jobs:
           fetch-depth: 0
       - run: echo "Checkout code"
       
-      - name: Setup Python ${{ matrix.python-version}}
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
@@ -30,7 +32,30 @@ jobs:
           pip install -r requirements.txt
       - run: echo "Installing Dependencies"
 
+      # Find all new or modified markdown files in the articles folder
+      - name: Find new and modified articles
+        id: find_files
+        run: |
+          # Find new or modified markdown files in the 'articles' directory
+          MODIFIED_FILES=$(git diff --name-only --diff-filter=ACM origin/main HEAD -- "articles/*.md")
+          if [ -z "$MODIFIED_FILES" ]; then
+            echo "No new or modified articles found."
+            echo "::set-output name=modified_files::"
+          else
+            echo "New or modified markdown files found:"
+            echo "$MODIFIED_FILES"
+            echo "::set-output name=modified_files::$MODIFIED_FILES"
+          fi
+
+      # Run sanity check for modified files
       - name: Run sanity check
         run: |
-          chmod +x sanity_check.sh
-          ./sanity_check.sh
+          if [ -z "${{ steps.find_files.outputs.modified_files }}" ]; then
+            echo "No articles to validate."
+          else
+            chmod +x sanity_check.sh
+            for file in ${{ steps.find_files.outputs.modified_files }}; do
+              echo "Validating $file..."
+              ./sanity_check.sh "$file"
+            done
+          fi

--- a/.github/workflows/notify-portmap.yml
+++ b/.github/workflows/notify-portmap.yml
@@ -6,14 +6,36 @@ on:
   workflow_dispatch:
 
 jobs:
+  validate-articles:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run sanity check
+      run: |
+        chmod +x sanity_check.sh
+        ./sanity_check.sh
+
   notify-portmap:
     runs-on: ubuntu-latest
+    needs: validate-articles  # This ensures the notify-portmap job only runs if validate-articles passes
     steps:
     - name: Send repository_dispatch
       uses: peter-evans/repository-dispatch@v3
       with:
-        # GitHub personal access token.
-        # See action description for instructions and requirements.
         token: ${{ secrets.PORTMAP_REPOSITORY_DISPATCH_PAT }}
         repository: dtinit/portmap
         event-type: content_update

--- a/sanity_check.sh
+++ b/sanity_check.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
 
-echo "Loading the Markdown files that have changed"
+echo "Loading the new and modified Markdown files in the articles folder"
 
-for x in $(git diff --name-only HEAD origin/main -- "articles/*.md")
-do
+# Find new or modified markdown files in the articles folder using git diff with ACM filter
+FILES=$(git diff --name-only --diff-filter=ACM HEAD origin/main -- "articles/*.md")
+
+# Check if any files were found
+if [ -z "$FILES" ]; then
+  echo "No new or modified markdown files found."
+  exit 0
+fi
+
+# Loop through the found files and run validation
+for x in $FILES; do
+  # Call the Python script to validate the file and store the result
   is_valid_md=$(python validate_markdown_metadata.py $x)
+
+  # If the result is "True", the file is valid, continue processing
   if [[ $is_valid_md == "True" ]]; then
     echo "Validating file $x"
   else

--- a/validate_markdown_metadata.py
+++ b/validate_markdown_metadata.py
@@ -43,36 +43,28 @@ def extract_yaml_and_body(file_content):
     body = '\n'.join(body_content)
     return yaml_content, body
 
+# Checks if a field is of the expected type
+def is_field_valid_type(field_name, field_value, expected_type, file_path):
+    if not isinstance(field_value, expected_type):
+        # If expected_type is a tuple (e.g., (str, list)), it means that multiple types are allowed
+        expected_types = (
+            # Constructing user-friendly string that describes the expected type(s)
+            f"{' or '.join([t.__name__ for t in expected_type])}"
+            if isinstance(expected_type, tuple)
+            else expected_type.__name__
+        )
+        raise ValueError(f"'{field_name}' must be a {expected_types} in {file_path}")
+
 # Validates the required fields in the frontmatter
 def validate_fields(frontmatter, file_path):
-
-    # Validate 'title': Must be a string
-    if not isinstance(frontmatter['title'], str):
-        raise ValueError(f"'title' must be a string in {file_path}")
-
-    # Validate 'datatype': Must be a string (no lists allowed)
-    if not isinstance(frontmatter['datatype'], str):
-        raise ValueError(f"'datatype' must be a string in {file_path}")
-
-    # Validate 'sources'
-    if isinstance(frontmatter['sources'], str):
-        # Single source, valid
-        pass
-    elif isinstance(frontmatter['sources'], list):
-        # Multiple sources, valid list format
-        pass
-    else:
-        raise ValueError(f"'sources' must be either a string or a list in {file_path}")
-
-    # Validate 'destinations'
-    if isinstance(frontmatter['destinations'], str):
-        # Single destination, valid
-        pass
-    elif isinstance(frontmatter['destinations'], list):
-        # Multiple destinations, valid list format
-        pass
-    else:
-        raise ValueError(f"'destinations' must be either a string or a list in {file_path}")
+    # 'title': Must be a string
+    is_field_valid_type('title', frontmatter['title'], str, file_path)
+    # 'datatype': Must be a string (no lists allowed)
+    is_field_valid_type('datatype', frontmatter['datatype'], str, file_path)
+    # 'sources': Must be a string or a list
+    is_field_valid_type('sources', frontmatter['sources'], (str, list), file_path)
+    # 'destinations': Must be a string or a list
+    is_field_valid_type('destinations', frontmatter['destinations'], (str, list), file_path)
     
 # Checks if a specified YAML field ends with a comma
 def does_field_end_with_comma(field, yaml_body):

--- a/validate_markdown_metadata.py
+++ b/validate_markdown_metadata.py
@@ -2,10 +2,19 @@ import sys
 import yaml
 import re
 
-# Helper function that checks if file content starts with a YAML header (---) before processing it
-# Modify from Portmap
+# Helper method that ensures the file has both a starting and ending '---'
 def has_yaml_header(file_content):
-    return file_content.strip().startswith('---')
+    """ Detects if a string (usually the contents of a .md file) has a YAML header
+    >>> has_yaml_header("---\\nTest: Yes\\n---")
+    True
+    >>> has_yaml_header("Test: No")
+    False
+    >>> has_yaml_header("---\\nProblem: about to be too many dashes\\n----")
+    False
+    """
+    p = re.compile(r"^---$", re.MULTILINE)
+    results = p.findall(file_content)
+    return len(results) > 1
 
 # This method is extracted from Portmap
 # and it should stay consistent with it if it needs updating

--- a/validate_markdown_metadata.py
+++ b/validate_markdown_metadata.py
@@ -1,20 +1,100 @@
-from sys import argv
+import sys
+import yaml
+import re
 
-import frontmatter
+def validate_frontmatter(file_path):
+    try:
+        # Open the markdown file and extract content
+        with open(file_path, 'r') as f:
+            # Split the content by '---' which indicates YAML frontmatter in markdown
+            content = f.read().split('---')
+            
+            # If there is no frontmatter section (should be between ---), raise an error
+            if len(content) < 3:
+                raise ValueError(f"No frontmatter found in {file_path}")
+            
+            # The actual YAML frontmatter is the second element (content[1])
+            frontmatter = yaml.safe_load(content[1])
+            
+            # Check if the parsed content is a dictionary (valid YAML structure)
+            if not isinstance(frontmatter, dict):
+                raise ValueError(f"Invalid frontmatter structure in {file_path}")
 
-KEYS = ['title', 'datatype', 'sources', 'destinations']
+            # Define the required fields in the frontmatter
+            required_fields = ['title', 'datatype', 'sources', 'destinations']
+            
+            # Check that all required fields are present
+            for field in required_fields:
+                if field not in frontmatter:
+                    raise ValueError(f"Missing field '{field}' in {file_path}")
 
-def article_validator(markdown_file):
-  article = frontmatter.load(markdown_file)
-  keys_indices = {key: index for index, key in enumerate(KEYS)}
-  sorted_keys = sorted(list(article.keys()), key=lambda x: keys_indices.get(x, float('inf')))
+            # Validate 'title': Must be a string
+            if not isinstance(frontmatter['title'], str):
+                raise ValueError(f"'title' must be a string in {file_path}")
 
-  return True if sorted_keys == KEYS else False
+            # Validate 'datatype': Must be a string (no lists allowed)
+            if not isinstance(frontmatter['datatype'], str):
+                raise ValueError(f"'datatype' must be a string in {file_path}")
 
-def main():
-  result = article_validator(argv[1])
-  return result
+            # Validate 'sources'
+            if isinstance(frontmatter['sources'], str):
+                # Single source, valid
+                pass
+            elif isinstance(frontmatter['sources'], list):
+                # Multiple sources, valid list format
+                pass
+            else:
+                raise ValueError(f"'sources' must be either a string or a list in {file_path}")
+
+            # Validate 'destinations'
+            if isinstance(frontmatter['destinations'], str):
+                # Single destination, valid
+                pass
+            elif isinstance(frontmatter['destinations'], list):
+                # Multiple destinations, valid list format
+                pass
+            else:
+                raise ValueError(f"'destinations' must be either a string or a list in {file_path}")
+
+            # Now check for trailing commas in all fields in the original content
+            # Using regex to match any fields that have a comma at the end of the line
+            errors = []
+
+            title_pattern = re.search(r'^title:\s*".*",\s*$', content[1], re.MULTILINE)
+            if title_pattern:
+                errors.append('title')
+
+            datatype_pattern = re.search(r'^datatype:\s*".*",\s*$', content[1], re.MULTILINE)
+            if datatype_pattern:
+                errors.append('datatype')
+
+            sources_pattern = re.search(r'^sources:\s*\[.*\],\s*$', content[1], re.MULTILINE)
+            if sources_pattern:
+                errors.append('sources')
+
+            destinations_pattern = re.search(r'^destinations:\s*\[.*\],\s*$', content[1], re.MULTILINE)
+            if destinations_pattern:
+                errors.append('destinations')
+
+            # If there are any errors, raise an error with the list of problematic fields
+            if errors:
+                raise ValueError(f"Trailing comma found in the following fields: {', '.join(errors)} in {file_path}")
+
+            # If all validations pass, return "True"
+            return "True"
+    
+    except yaml.YAMLError as e:
+        # Catch any YAML syntax errors
+        print(f"YAML Error in {file_path}: {e}")
+        return "False"
+    
+    except Exception as e:
+        # Catch other errors (missing fields, invalid structure, trailing comma, etc.)
+        print(f"Error in {file_path}: {e}")
+        return "False"
 
 if __name__ == "__main__":
-    print(main())
-    
+    # The script takes the file path as an argument
+    file_path = sys.argv[1]
+    # Run validation and print the result ("True" or "False")
+    print(validate_frontmatter(file_path))

--- a/validate_markdown_metadata.py
+++ b/validate_markdown_metadata.py
@@ -43,6 +43,37 @@ def extract_yaml_and_body(file_content):
     body = '\n'.join(body_content)
     return yaml_content, body
 
+# Validates the required fields in the frontmatter
+def validate_fields(frontmatter, file_path):
+
+    # Validate 'title': Must be a string
+    if not isinstance(frontmatter['title'], str):
+        raise ValueError(f"'title' must be a string in {file_path}")
+
+    # Validate 'datatype': Must be a string (no lists allowed)
+    if not isinstance(frontmatter['datatype'], str):
+        raise ValueError(f"'datatype' must be a string in {file_path}")
+
+    # Validate 'sources'
+    if isinstance(frontmatter['sources'], str):
+        # Single source, valid
+        pass
+    elif isinstance(frontmatter['sources'], list):
+        # Multiple sources, valid list format
+        pass
+    else:
+        raise ValueError(f"'sources' must be either a string or a list in {file_path}")
+
+    # Validate 'destinations'
+    if isinstance(frontmatter['destinations'], str):
+        # Single destination, valid
+        pass
+    elif isinstance(frontmatter['destinations'], list):
+        # Multiple destinations, valid list format
+        pass
+    else:
+        raise ValueError(f"'destinations' must be either a string or a list in {file_path}")
+
 def validate_frontmatter(file_path):
     try:
         # Open the markdown file and extract content
@@ -53,45 +84,8 @@ def validate_frontmatter(file_path):
             # Extract frontmatter and body using Portmap method
             frontmatter, _ = extract_yaml_and_body(content)
             
-            # Check if the parsed content is a dictionary (valid YAML structure)
-            if not isinstance(frontmatter, dict):
-                raise ValueError(f"Invalid frontmatter structure in {file_path}")
-
-            # Define the required fields in the frontmatter
-            required_fields = ['title', 'datatype', 'sources', 'destinations']
-            
-            # Check that all required fields are present
-            for field in required_fields:
-                if field not in frontmatter:
-                    raise ValueError(f"Missing field '{field}' in {file_path}")
-
-            # Validate 'title': Must be a string
-            if not isinstance(frontmatter['title'], str):
-                raise ValueError(f"'title' must be a string in {file_path}")
-
-            # Validate 'datatype': Must be a string (no lists allowed)
-            if not isinstance(frontmatter['datatype'], str):
-                raise ValueError(f"'datatype' must be a string in {file_path}")
-
-            # Validate 'sources'
-            if isinstance(frontmatter['sources'], str):
-                # Single source, valid
-                pass
-            elif isinstance(frontmatter['sources'], list):
-                # Multiple sources, valid list format
-                pass
-            else:
-                raise ValueError(f"'sources' must be either a string or a list in {file_path}")
-
-            # Validate 'destinations'
-            if isinstance(frontmatter['destinations'], str):
-                # Single destination, valid
-                pass
-            elif isinstance(frontmatter['destinations'], list):
-                # Multiple destinations, valid list format
-                pass
-            else:
-                raise ValueError(f"'destinations' must be either a string or a list in {file_path}")
+            # Validate the extracted frontmatter
+            validate_fields(frontmatter, file_path)
 
             # Now check for trailing commas in all fields in the original content
             # Using regex to match any fields that have a comma at the end of the line

--- a/validate_markdown_metadata.py
+++ b/validate_markdown_metadata.py
@@ -73,6 +73,12 @@ def validate_fields(frontmatter, file_path):
         pass
     else:
         raise ValueError(f"'destinations' must be either a string or a list in {file_path}")
+    
+# Checks if a specified YAML field ends with a comma
+def does_field_end_with_comma(field, yaml_body):
+    datatype_pattern = re.compile(r"^" + re.escape(field) + r":\s*.*,\s*$", re.MULTILINE)
+    match = datatype_pattern.search(yaml_body)
+    return match is not None
 
 def validate_frontmatter(file_path):
     try:
@@ -87,27 +93,12 @@ def validate_frontmatter(file_path):
             # Validate the extracted frontmatter
             validate_fields(frontmatter, file_path)
 
-            # Now check for trailing commas in all fields in the original content
-            # Using regex to match any fields that have a comma at the end of the line
-            errors = []
+            # Check for trailing commas
+            fields_to_check = ['title', 'datatype', 'sources', 'destinations']
+            # Iterate over fields to check and then check for trailing commas
+            errors = [field for field in fields_to_check if does_field_end_with_comma(field, content)]
 
-            title_pattern = re.search(r'^title:\s*".*",\s*$', content[1], re.MULTILINE)
-            if title_pattern:
-                errors.append('title')
-
-            datatype_pattern = re.search(r'^datatype:\s*".*",\s*$', content[1], re.MULTILINE)
-            if datatype_pattern:
-                errors.append('datatype')
-
-            sources_pattern = re.search(r'^sources:\s*\[.*\],\s*$', content[1], re.MULTILINE)
-            if sources_pattern:
-                errors.append('sources')
-
-            destinations_pattern = re.search(r'^destinations:\s*\[.*\],\s*$', content[1], re.MULTILINE)
-            if destinations_pattern:
-                errors.append('destinations')
-
-            # If there are any errors, raise an error with the list of problematic fields
+            # If there are any fields with trailing commas, raise an error
             if errors:
                 raise ValueError(f"Trailing comma found in the following fields: {', '.join(errors)} in {file_path}")
 


### PR DESCRIPTION
### **Restructuring markdown validations and updating sanity check:**

The `git diff` command now uses the `--diff-filter=ACM` option to detect files that are:

- **Added** (A): Newly added files.
- **Modified** (M): Files with changes.
- **Copied** (C): Optionally, it will capture copied files.


**How It Works:**

1. **Detect Changes**: The `git diff --name-only --diff-filter=ACM` command lists all markdown files in the articles folder that are either new or modified.
2. **Validation**: For each detected file, the `validate_markdown_metadata.py` script is run.
3. **Failure Handling**: If any file fails validation, the script exits with an error, stopping further execution.

Closes #77 

### New and modified articles are validated when PRs are opened for the main branch, and the results are visible as a check for the PR

It will achieves the following:

1. **Validate articles** when a **pull request** is opened or reopened.
2. **Validate only new or modified markdown files** within the articles folder, based on the changes in the PR.

1. **Triggering Events**:
    - **pull_request**: The workflow runs when a pull request is opened, reopened, or synchronized (when new commits are pushed to the PR).
    - **push**: The workflow also runs when code is pushed to the main branch.
2. **Detecting New and Modified Files**:
    - The step Find new and modified articles uses git diff to find files in the articles folder that are either **newly added** (A) or **modified** (M).

1. **Running Sanity Check**:
- The Run sanity check step runs your sanity_check.sh script only for the new or modified markdown files detected in the previous step.
- The script is executed with each markdown file as a parameter `./sanity_check.sh "$file"`

If no markdown files are found, the workflow exits early without running the validation script, improving efficiency.

**PR Checks:**

- When a pull request is opened, updated, or reopened, this workflow will automatically detect any new or modified articles in the articles folder and run the validation script.
- If any validation fails, the workflow will fail, and this failure will appear as a check on the PR.
- After pushing to main, the same workflow will run, ensuring that changes directly pushed to main are also validated.

Closes #78 

### Ensure any validation issues block the deployment notification to Portmap introduced in Add workflow to notify Portmap of content updates #65

To ensure that any validation issues block the deployment notification to Portmap, we can introduce a validation step before the notify-portmap job in our GitHub workflow. If the validation step fails, it will prevent the subsequent steps (including the notification to Portmap) from executing.

1. **Separate Job for Validation (validate-articles)**:
    - This job performs the validation of your articles before triggering the notification.
    - It checks out the repository, sets up Python, installs dependencies, and runs the `sanity_check.sh` script to validate new or modified markdown files.
2. **Block Notification if Validation Fails**:
    - The notify-portmap job has the line needs: validate-articles. This ensures that the notify-portmap job only runs if the validate-articles job completes successfully.
    - If any validation fails (e.g., the `sanity_check.sh` script returns an error), the entire workflow will stop, preventing the notification from being sent to Portmap.

Closes #79 

Closes #68 